### PR TITLE
remove rosbag2 dependency

### DIFF
--- a/iceoryx_ros2_bridge/src/typesupport_helpers.hpp
+++ b/iceoryx_ros2_bridge/src/typesupport_helpers.hpp
@@ -20,16 +20,13 @@
 #include <utility>
 
 #include "rosidl_generator_cpp/message_type_support_decl.hpp"
-#include "rosbag2/visibility_control.hpp"
 
 namespace iceoryx_ros2_bridge
 {
 
-ROSBAG2_PUBLIC
 const rosidl_message_type_support_t *
 get_typesupport(const std::string & type, const std::string & typesupport_identifier);
 
-ROSBAG2_PUBLIC
 const std::tuple<std::string, std::string, std::string>
 extract_type_identifier(const std::string & full_type);
 


### PR DESCRIPTION
fixes https://github.com/ros2/rmw_iceoryx/issues/1

The typesupport helpers as well as the generic sub/pub are a direct copy of the code available in rosbag2. I thought there was already an open issue for it, but ideally that code should live somewhere in rosidl or rclcpp.

Signed-off-by: Knese Karsten <karsten@openrobotics.org>