### PR TITLE
apply changes for latest iceoryx API

### DIFF
--- a/rmw_iceoryx_cpp/src/internal/iceoryx_topic_names_and_types.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_topic_names_and_types.cpp
@@ -55,19 +55,20 @@ void fill_topic_containers(
 
   if (updated) {
     // get the latest sample
-    const iox::mepoo::ChunkInfo * chunkInfo = nullptr;
-    const iox::mepoo::ChunkInfo * latestChunkInfo = nullptr;
+    const iox::mepoo::ChunkHeader * chunk_header = nullptr;
+    const iox::mepoo::ChunkHeader * latest_chunk_header = nullptr;
 
-    while (port_receiver.getChunkWithInfo(&chunkInfo)) {
-      if (latestChunkInfo) {
-        port_receiver.releaseChunkWithInfo(latestChunkInfo);
+    while (port_receiver.getChunk(&chunk_header)) {
+      if (latest_chunk_header) {
+        port_receiver.releaseChunk(latest_chunk_header);
       }
-      latestChunkInfo = chunkInfo;
+      latest_chunk_header = chunk_header;
     }
 
-    if (latestChunkInfo) {
+    if (latest_chunk_header) {
       const iox::roudi::PortIntrospectionFieldTopic * port_sample =
-        static_cast<const iox::roudi::PortIntrospectionFieldTopic *>(latestChunkInfo->m_payload);
+        static_cast<const iox::roudi::PortIntrospectionFieldTopic *>(latest_chunk_header->
+        m_payload);
 
       names_n_types.clear();
       subscribers_topics.clear();
@@ -93,7 +94,7 @@ void fill_topic_containers(
         publishers_topics[std::string(sender.m_runnable.to_cstring())].push_back(std::get<0>(
             name_and_type));
       }
-      port_receiver.releaseChunkWithInfo(latestChunkInfo);
+      port_receiver.releaseChunk(latest_chunk_header);
     }
   }
 

--- a/rmw_iceoryx_cpp/src/rmw_node_names.cpp
+++ b/rmw_iceoryx_cpp/src/rmw_node_names.cpp
@@ -60,19 +60,20 @@ rmw_get_node_names(
 
   if (updated) {
     // get the latest sample
-    const iox::mepoo::ChunkInfo * chunkInfo = nullptr;
-    const iox::mepoo::ChunkInfo * latestChunkInfo = nullptr;
+    const iox::mepoo::ChunkHeader * chunk_header = nullptr;
+    const iox::mepoo::ChunkHeader * latest_chunk_header = nullptr;
 
-    while (process_receiver.getChunkWithInfo(&chunkInfo)) {
-      if (latestChunkInfo) {
-        process_receiver.releaseChunkWithInfo(latestChunkInfo);
+    while (process_receiver.getChunk(&chunk_header)) {
+      if (latest_chunk_header) {
+        process_receiver.releaseChunk(latest_chunk_header);
       }
-      latestChunkInfo = chunkInfo;
+      latest_chunk_header = chunk_header;
     }
 
-    if (latestChunkInfo) {
+    if (latest_chunk_header) {
       const iox::roudi::ProcessIntrospectionFieldTopic * process_sample =
-        static_cast<const iox::roudi::ProcessIntrospectionFieldTopic *>(latestChunkInfo->m_payload);
+        static_cast<const iox::roudi::ProcessIntrospectionFieldTopic *>(latest_chunk_header->
+        m_payload);
 
       node_names_set.clear();
       for (auto & process : process_sample->m_processList) {
@@ -80,7 +81,7 @@ rmw_get_node_names(
           node_names_set.insert(std::string(runnable.to_cstring()));
         }
       }
-      process_receiver.releaseChunkWithInfo(latestChunkInfo);
+      process_receiver.releaseChunk(latest_chunk_header);
     }
   }
 

--- a/rmw_iceoryx_cpp/src/rmw_take.cpp
+++ b/rmw_iceoryx_cpp/src/rmw_take.cpp
@@ -75,16 +75,16 @@ rmw_take(
     return RMW_RET_ERROR;
   }
 
-  const iox::mepoo::ChunkInfo * chunk_info = nullptr;
-  if (!iceoryx_receiver->getChunkWithInfo(&chunk_info)) {
+  const iox::mepoo::ChunkHeader * chunk_header = nullptr;
+  if (!iceoryx_receiver->getChunk(&chunk_header)) {
     RMW_SET_ERROR_MSG("No chunk in iceoryx_receiver");
     return RMW_RET_ERROR;
   }
 
   // if fixed size, we fetch the data via memcpy
   if (iceoryx_subscription->is_fixed_size_) {
-    memcpy(ros_message, chunk_info->m_payload, chunk_info->m_payloadSize);
-    iceoryx_receiver->releaseChunkWithInfo(chunk_info);
+    memcpy(ros_message, chunk_header->m_payload, chunk_header->m_info.m_payloadSize);
+    iceoryx_receiver->releaseChunk(chunk_header);
     *taken = true;
     return RMW_RET_OK;
   }
@@ -97,8 +97,8 @@ rmw_take(
     auto members =
       static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(ts_cpp->data);
     rmw_iceoryx_cpp::deserialize(
-      static_cast<const char *>(chunk_info->m_payload), members, ros_message);
-    iceoryx_receiver->releaseChunkWithInfo(chunk_info);
+      static_cast<const char *>(chunk_header->m_payload), members, ros_message);
+    iceoryx_receiver->releaseChunk(chunk_header);
     *taken = true;
   }
 
@@ -110,8 +110,8 @@ rmw_take(
     auto members =
       static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(ts_c->data);
     rmw_iceoryx_cpp::deserialize(
-      static_cast<const char *>(chunk_info->m_payload), members, ros_message);
-    iceoryx_receiver->releaseChunkWithInfo(chunk_info);
+      static_cast<const char *>(chunk_header->m_payload), members, ros_message);
+    iceoryx_receiver->releaseChunk(chunk_header);
     *taken = true;
   }
 


### PR DESCRIPTION
iceoryx's latest commits introduced a breaking change to their existing API. This PR reflects these changes in the rmw implementation.

cc @michael-poehnl 

CI:
[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8871)](https://ci.ros2.org/job/ci_linux/8871/)

Signed-off-by: Knese Karsten <karsten.knese@us.bosch.com>