### PR TITLE
force lower case for ros package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+![Integration build and tests](https://github.com/ros2/rmw_iceoryx/workflows/Integration%20build%20rmw_iceoryx/badge.svg)
+![Linting](https://github.com/ros2/rmw_iceoryx/workflows/Lint%20rmw_iceoryx/badge.svg)
+![Iceoryx build and tests](https://github.com/ros2/rmw_iceoryx/workflows/Build%20iceoryx/badge.svg)
+
 Installation
 ============
 

--- a/iceoryx_ros2_bridge/src/iceoryx_ros2_bridge.cpp
+++ b/iceoryx_ros2_bridge/src/iceoryx_ros2_bridge.cpp
@@ -225,8 +225,9 @@ int main(int argc, char ** argv)
 
     auto service_desc =
       rmw_iceoryx_cpp::get_iceoryx_service_description(topic, ts);
-    iceoryx_pubs.emplace_back(std::make_shared<iox::popo::Publisher>(
-      service_desc, iox::cxx::CString100(iox::cxx::TruncateToCapacity, node_name)));  
+    iceoryx_pubs.emplace_back(
+      std::make_shared<iox::popo::Publisher>(
+        service_desc, iox::cxx::CString100(iox::cxx::TruncateToCapacity, node_name)));
     iceoryx_pubs.back()->offer();
 
     std::function<void(std::shared_ptr<rmw_serialized_message_t>)> cb =
@@ -269,8 +270,9 @@ int main(int argc, char ** argv)
 
     auto service_desc =
       rmw_iceoryx_cpp::get_iceoryx_service_description(topic, ts);
-    iceoryx_subs.emplace_back(std::make_shared<iox::popo::Subscriber>(
-      service_desc, iox::cxx::CString100(iox::cxx::TruncateToCapacity, node_name)));
+    iceoryx_subs.emplace_back(
+      std::make_shared<iox::popo::Subscriber>(
+        service_desc, iox::cxx::CString100(iox::cxx::TruncateToCapacity, node_name)));
     iceoryx_subs.back()->subscribe(10);  // TODO(karsten1987): find a decent queue size
 
     auto cb =

--- a/rmw_iceoryx_cpp/CMakeLists.txt
+++ b/rmw_iceoryx_cpp/CMakeLists.txt
@@ -139,6 +139,8 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(${PROJECT_NAME}_tests test/iceoryx_name_conversion_test.cpp)
+
+  target_link_libraries(${PROJECT_NAME}_tests ${PROJECT_NAME})
 endif()
 
 ament_export_include_directories(include)

--- a/rmw_iceoryx_cpp/CMakeLists.txt
+++ b/rmw_iceoryx_cpp/CMakeLists.txt
@@ -136,6 +136,9 @@ install(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(${PROJECT_NAME}_tests test/iceoryx_name_conversion_test.cpp)
 endif()
 
 ament_export_include_directories(include)

--- a/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_name_conversion.hpp
+++ b/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_name_conversion.hpp
@@ -27,13 +27,13 @@ namespace rmw_iceoryx_cpp
 {
 
 std::tuple<std::string, std::string>
-get_name_n_type_from_iceoryx_service_description(
+get_name_n_type_from_service_description(
   const std::string & service,
   const std::string & instance,
   const std::string & event);
 
 std::tuple<std::string, std::string, std::string>
-get_service_description_elements(
+get_service_description_from_name_n_type(
   const std::string & topic_name,
   const std::string & type_name);
 

--- a/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_name_conversion.hpp
+++ b/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_name_conversion.hpp
@@ -32,6 +32,11 @@ get_name_n_type_from_iceoryx_service_description(
   const std::string & instance,
   const std::string & event);
 
+std::tuple<std::string, std::string, std::string>
+get_service_description_elements(
+  const std::string & topic_name,
+  const std::string & type_name);
+
 iox::capro::ServiceDescription
 get_iceoryx_service_description(
   const std::string & topic,

--- a/rmw_iceoryx_cpp/package.xml
+++ b/rmw_iceoryx_cpp/package.xml
@@ -21,6 +21,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmw_iceoryx_cpp/package.xml
+++ b/rmw_iceoryx_cpp/package.xml
@@ -19,9 +19,9 @@
   <depend>rosidl_typesupport_introspection_c</depend>
   <depend>rosidl_typesupport_introspection_cpp</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -35,7 +35,7 @@
 #include "rmw_iceoryx_cpp/iceoryx_name_conversion.hpp"
 #include "rmw_iceoryx_cpp/iceoryx_type_info_introspection.hpp"
 
-static const std::string DELIMITER_MSG = "_ara_msgs/msg/";
+static const char DELIMITER_MSG[] = "_ara_msgs/msg/";
 
 std::tuple<std::string, std::string, std::string> get_service_description_elements(
   const std::string & topic_name,
@@ -62,7 +62,7 @@ std::tuple<std::string, std::string, std::string> get_service_description_elemen
 
   auto service = topic_name.substr(pos_package_name, service_lowercase.length());
   auto instance = topic_name.substr(1, pos_package_name - 2);       // / before and after
-  auto event = type_name.substr(pos_delimiter_msg + DELIMITER_MSG.size(), type_name.size());
+  auto event = type_name.substr(pos_delimiter_msg + strlen(DELIMITER_MSG), type_name.size());
 
   return std::make_tuple(service, instance, event);
 }

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -49,13 +49,15 @@ std::tuple<std::string, std::string, std::string> get_service_description_elemen
   }
 
   // Could check more detailed!!
-  auto service = type_name.substr(0, pos_msg);
-  auto pos_type_name = topic_name.find(type_name);
-  auto pos_package_name = topic_name.find(service);
-  if (pos_type_name == std::string::npos || pos_package_name == std::string::npos) {
+  auto service_lowercase = type_name.substr(0, pos_msg);
+  std::string topic_name_lowercase = topic_name;
+  transform(topic_name_lowercase.begin(), topic_name_lowercase.end(), topic_name_lowercase.begin(), ::tolower);
+  auto pos_package_name = topic_name_lowercase.find(service_lowercase);
+  if (pos_package_name == std::string::npos) {
     throw std::runtime_error("message topic and type are inconsistent");
   }
 
+  auto service = topic_name.substr(pos_package_name, service_lowercase.length());
   auto instance = topic_name.substr(1, pos_package_name - 2);       // / before and after
   auto event = type_name.substr(pos_msg + delimiter_msg.size(), type_name.size());
 
@@ -102,10 +104,11 @@ get_name_n_type_from_iceoryx_service_description(
   } else {
     // ARA Naming
     std::string delimiter_msg = "_ara_msgs/msg/";
+    std::string service_lowercase = service;
+    transform(service_lowercase.begin(), service_lowercase.end(), service_lowercase.begin(), ::tolower);
 
-    return std::make_tuple(
-      "/" + instance + "/" + service + "/" + event,
-      service + delimiter_msg + event);
+    return std::make_tuple("/" + instance + "/" + service + "/" + event,
+             service_lowercase + delimiter_msg + event);
   }
 }
 

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -35,7 +35,7 @@
 #include "rmw_iceoryx_cpp/iceoryx_name_conversion.hpp"
 #include "rmw_iceoryx_cpp/iceoryx_type_info_introspection.hpp"
 
-static const char DELIMITER_MSG[] = "_ara_msgs/msg/";
+static const char ARA_DELIMITER[] = "_ara_msgs/msg/";
 
 
 std::string to_message_type(const std::string & in)
@@ -81,34 +81,42 @@ get_name_n_type_from_iceoryx_service_description(
 
   return std::make_tuple(
     "/" + instance + "/" + service + "/" + event,
-    service_lowercase + DELIMITER_MSG + event);
+    service_lowercase + ARA_DELIMITER + event);
 }
 
 std::tuple<std::string, std::string, std::string> get_service_description_elements(
   const std::string & topic_name,
   const std::string & type_name)
 {
-  auto pos_delimiter_msg = type_name.find(DELIMITER_MSG);
+  auto position_ara_delimiter = type_name.find(ARA_DELIMITER);
 
-  if (pos_delimiter_msg == std::string::npos) {
+  if (position_ara_delimiter == std::string::npos) {
     // ROS 2.0 Naming
     return std::make_tuple(type_name, topic_name, "data");
   }
 
   // ARA Naming
-  auto service_lowercase = type_name.substr(0, pos_delimiter_msg);
+  // Due to ros package naming conventions the service name packed into
+  // the type name had to be lowercase
+  auto service_lowercase = type_name.substr(0, position_ara_delimiter);
+
   std::string topic_name_lowercase = topic_name;
   std::transform(
     topic_name_lowercase.begin(), topic_name_lowercase.end(),
     topic_name_lowercase.begin(), ::tolower);
-  auto pos_package_name = topic_name_lowercase.find(service_lowercase);
-  if (pos_package_name == std::string::npos) {
+
+  // Find the lowercase service name in the lowercased topic name
+  auto position_package_name = topic_name_lowercase.find(service_lowercase);
+
+  if (position_package_name == std::string::npos) {
     throw std::runtime_error("message topic and type are inconsistent");
   }
 
-  auto service = topic_name.substr(pos_package_name, service_lowercase.length());
-  auto instance = topic_name.substr(1, pos_package_name - 2);       // / before and after
-  auto event = type_name.substr(pos_delimiter_msg + strlen(DELIMITER_MSG), type_name.size());
+  // Get the mixed uppercase and lowercase service name
+  // knowing the strings position in the topic name
+  auto service = topic_name.substr(position_package_name, service_lowercase.length());
+  auto instance = topic_name.substr(1, position_package_name - 2);
+  auto event = type_name.substr(position_ara_delimiter + strlen(ARA_DELIMITER), type_name.size());
 
   return std::make_tuple(service, instance, event);
 }

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -40,18 +40,20 @@ std::tuple<std::string, std::string, std::string> get_service_description_elemen
   const std::string & type_name)
 {
   std::string delimiter_msg = "_ara_msgs/msg/";
-  auto pos_msg = type_name.find(delimiter_msg);
+  auto pos_delimiter_msg = type_name.find(delimiter_msg);
 
   // ROS 2.0 Naming
-  if (pos_msg == std::string::npos) {
+  if (pos_delimiter_msg == std::string::npos) {
     // service, instance, event
     return std::make_tuple(type_name, topic_name, "data");
   }
 
   // Could check more detailed!!
-  auto service_lowercase = type_name.substr(0, pos_msg);
+  auto service_lowercase = type_name.substr(0, pos_delimiter_msg);
   std::string topic_name_lowercase = topic_name;
-  transform(topic_name_lowercase.begin(), topic_name_lowercase.end(), topic_name_lowercase.begin(), ::tolower);
+  std::transform(
+    topic_name_lowercase.begin(), topic_name_lowercase.end(),
+    topic_name_lowercase.begin(), ::tolower);
   auto pos_package_name = topic_name_lowercase.find(service_lowercase);
   if (pos_package_name == std::string::npos) {
     throw std::runtime_error("message topic and type are inconsistent");
@@ -59,7 +61,7 @@ std::tuple<std::string, std::string, std::string> get_service_description_elemen
 
   auto service = topic_name.substr(pos_package_name, service_lowercase.length());
   auto instance = topic_name.substr(1, pos_package_name - 2);       // / before and after
-  auto event = type_name.substr(pos_msg + delimiter_msg.size(), type_name.size());
+  auto event = type_name.substr(pos_delimiter_msg + delimiter_msg.size(), type_name.size());
 
   return std::make_tuple(service, instance, event);
 }
@@ -105,10 +107,13 @@ get_name_n_type_from_iceoryx_service_description(
     // ARA Naming
     std::string delimiter_msg = "_ara_msgs/msg/";
     std::string service_lowercase = service;
-    transform(service_lowercase.begin(), service_lowercase.end(), service_lowercase.begin(), ::tolower);
+    std::transform(
+      service_lowercase.begin(), service_lowercase.end(),
+      service_lowercase.begin(), ::tolower);
 
-    return std::make_tuple("/" + instance + "/" + service + "/" + event,
-             service_lowercase + delimiter_msg + event);
+    return std::make_tuple(
+      "/" + instance + "/" + service + "/" + event,
+      service_lowercase + delimiter_msg + event);
   }
 }
 

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -37,35 +37,6 @@
 
 static const char DELIMITER_MSG[] = "_ara_msgs/msg/";
 
-std::tuple<std::string, std::string, std::string> get_service_description_elements(
-  const std::string & topic_name,
-  const std::string & type_name)
-{
-  auto pos_delimiter_msg = type_name.find(DELIMITER_MSG);
-
-  // ROS 2.0 Naming
-  if (pos_delimiter_msg == std::string::npos) {
-    // service, instance, event
-    return std::make_tuple(type_name, topic_name, "data");
-  }
-
-  // Could check more detailed!!
-  auto service_lowercase = type_name.substr(0, pos_delimiter_msg);
-  std::string topic_name_lowercase = topic_name;
-  std::transform(
-    topic_name_lowercase.begin(), topic_name_lowercase.end(),
-    topic_name_lowercase.begin(), ::tolower);
-  auto pos_package_name = topic_name_lowercase.find(service_lowercase);
-  if (pos_package_name == std::string::npos) {
-    throw std::runtime_error("message topic and type are inconsistent");
-  }
-
-  auto service = topic_name.substr(pos_package_name, service_lowercase.length());
-  auto instance = topic_name.substr(1, pos_package_name - 2);       // / before and after
-  auto event = type_name.substr(pos_delimiter_msg + strlen(DELIMITER_MSG), type_name.size());
-
-  return std::make_tuple(service, instance, event);
-}
 
 std::string to_message_type(const std::string & in)
 {
@@ -115,6 +86,36 @@ get_name_n_type_from_iceoryx_service_description(
       "/" + instance + "/" + service + "/" + event,
       service_lowercase + DELIMITER_MSG + event);
   }
+}
+
+std::tuple<std::string, std::string, std::string> get_service_description_elements(
+  const std::string & topic_name,
+  const std::string & type_name)
+{
+  auto pos_delimiter_msg = type_name.find(DELIMITER_MSG);
+
+  // ROS 2.0 Naming
+  if (pos_delimiter_msg == std::string::npos) {
+    // service, instance, event
+    return std::make_tuple(type_name, topic_name, "data");
+  }
+
+  // Could check more detailed!!
+  auto service_lowercase = type_name.substr(0, pos_delimiter_msg);
+  std::string topic_name_lowercase = topic_name;
+  std::transform(
+    topic_name_lowercase.begin(), topic_name_lowercase.end(),
+    topic_name_lowercase.begin(), ::tolower);
+  auto pos_package_name = topic_name_lowercase.find(service_lowercase);
+  if (pos_package_name == std::string::npos) {
+    throw std::runtime_error("message topic and type are inconsistent");
+  }
+
+  auto service = topic_name.substr(pos_package_name, service_lowercase.length());
+  auto instance = topic_name.substr(1, pos_package_name - 2);       // / before and after
+  auto event = type_name.substr(pos_delimiter_msg + strlen(DELIMITER_MSG), type_name.size());
+
+  return std::make_tuple(service, instance, event);
 }
 
 iox::capro::ServiceDescription

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -35,12 +35,13 @@
 #include "rmw_iceoryx_cpp/iceoryx_name_conversion.hpp"
 #include "rmw_iceoryx_cpp/iceoryx_type_info_introspection.hpp"
 
+static const std::string DELIMITER_MSG = "_ara_msgs/msg/";
+
 std::tuple<std::string, std::string, std::string> get_service_description_elements(
   const std::string & topic_name,
   const std::string & type_name)
 {
-  std::string delimiter_msg = "_ara_msgs/msg/";
-  auto pos_delimiter_msg = type_name.find(delimiter_msg);
+  auto pos_delimiter_msg = type_name.find(DELIMITER_MSG);
 
   // ROS 2.0 Naming
   if (pos_delimiter_msg == std::string::npos) {
@@ -61,7 +62,7 @@ std::tuple<std::string, std::string, std::string> get_service_description_elemen
 
   auto service = topic_name.substr(pos_package_name, service_lowercase.length());
   auto instance = topic_name.substr(1, pos_package_name - 2);       // / before and after
-  auto event = type_name.substr(pos_delimiter_msg + delimiter_msg.size(), type_name.size());
+  auto event = type_name.substr(pos_delimiter_msg + DELIMITER_MSG.size(), type_name.size());
 
   return std::make_tuple(service, instance, event);
 }
@@ -105,7 +106,6 @@ get_name_n_type_from_iceoryx_service_description(
     return std::make_tuple(instance, service);
   } else {
     // ARA Naming
-    std::string delimiter_msg = "_ara_msgs/msg/";
     std::string service_lowercase = service;
     std::transform(
       service_lowercase.begin(), service_lowercase.end(),
@@ -113,7 +113,7 @@ get_name_n_type_from_iceoryx_service_description(
 
     return std::make_tuple(
       "/" + instance + "/" + service + "/" + event,
-      service_lowercase + delimiter_msg + event);
+      service_lowercase + DELIMITER_MSG + event);
   }
 }
 

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -36,6 +36,7 @@
 #include "rmw_iceoryx_cpp/iceoryx_type_info_introspection.hpp"
 
 static const char ARA_DELIMITER[] = "_ara_msgs/msg/";
+static const char ROS2_EVENT_NAME[] = "data";
 
 
 std::string to_message_type(const std::string & in)
@@ -69,7 +70,7 @@ get_name_n_type_from_iceoryx_service_description(
   const std::string & instance,
   const std::string & event)
 {
-  if (event == "data") {
+  if (event == ROS2_EVENT_NAME) {
     // ROS 2.0 Naming
     return std::make_tuple(instance, service);
   }
@@ -92,7 +93,7 @@ std::tuple<std::string, std::string, std::string> get_service_description_elemen
 
   if (position_ara_delimiter == std::string::npos) {
     // ROS 2.0 Naming
-    return std::make_tuple(type_name, topic_name, "data");
+    return std::make_tuple(type_name, topic_name, ROS2_EVENT_NAME);
   }
 
   // ARA Naming

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -65,7 +65,7 @@ namespace rmw_iceoryx_cpp
 {
 
 std::tuple<std::string, std::string>
-get_name_n_type_from_iceoryx_service_description(
+get_name_n_type_from_service_description(
   const std::string & service,
   const std::string & instance,
   const std::string & event)
@@ -85,7 +85,7 @@ get_name_n_type_from_iceoryx_service_description(
     service_lowercase + ARA_DELIMITER + event);
 }
 
-std::tuple<std::string, std::string, std::string> get_service_description_elements(
+std::tuple<std::string, std::string, std::string> get_service_description_from_name_n_type(
   const std::string & topic_name,
   const std::string & type_name)
 {
@@ -132,7 +132,7 @@ get_iceoryx_service_description(
   extract_type(type_supports, package_name, type_name);
   type_name = package_name + "/" + type_name;
 
-  auto serviceDescriptionTuple = get_service_description_elements(topic_name, type_name);
+  auto serviceDescriptionTuple = get_service_description_from_name_n_type(topic_name, type_name);
 
   return iox::capro::ServiceDescription(
     iox::capro::IdString(iox::cxx::TruncateToCapacity, std::get<0>(serviceDescriptionTuple)),

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -69,23 +69,19 @@ get_name_n_type_from_iceoryx_service_description(
   const std::string & instance,
   const std::string & event)
 {
-  std::string topic_name;
-  std::string type_name;
-
-  if (service.find("/msg/") != std::string::npos) {
+  if (event == "data") {
     // ROS 2.0 Naming
     return std::make_tuple(instance, service);
-  } else {
-    // ARA Naming
-    std::string service_lowercase = service;
-    std::transform(
-      service_lowercase.begin(), service_lowercase.end(),
-      service_lowercase.begin(), ::tolower);
-
-    return std::make_tuple(
-      "/" + instance + "/" + service + "/" + event,
-      service_lowercase + DELIMITER_MSG + event);
   }
+  // ARA Naming
+  std::string service_lowercase = service;
+  std::transform(
+    service_lowercase.begin(), service_lowercase.end(),
+    service_lowercase.begin(), ::tolower);
+
+  return std::make_tuple(
+    "/" + instance + "/" + service + "/" + event,
+    service_lowercase + DELIMITER_MSG + event);
 }
 
 std::tuple<std::string, std::string, std::string> get_service_description_elements(
@@ -94,13 +90,12 @@ std::tuple<std::string, std::string, std::string> get_service_description_elemen
 {
   auto pos_delimiter_msg = type_name.find(DELIMITER_MSG);
 
-  // ROS 2.0 Naming
   if (pos_delimiter_msg == std::string::npos) {
-    // service, instance, event
+    // ROS 2.0 Naming
     return std::make_tuple(type_name, topic_name, "data");
   }
 
-  // Could check more detailed!!
+  // ARA Naming
   auto service_lowercase = type_name.substr(0, pos_delimiter_msg);
   std::string topic_name_lowercase = topic_name;
   std::transform(

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_topic_names_and_types.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_topic_names_and_types.cpp
@@ -75,7 +75,7 @@ void fill_topic_containers(
       publishers_topics.clear();
 
       for (auto & receiver : port_sample->m_receiverList) {
-        auto name_and_type = rmw_iceoryx_cpp::get_name_n_type_from_iceoryx_service_description(
+        auto name_and_type = rmw_iceoryx_cpp::get_name_n_type_from_service_description(
           std::string(receiver.m_caproServiceID.c_str()),
           std::string(receiver.m_caproInstanceID.c_str()),
           std::string(receiver.m_caproEventMethodID.c_str()));
@@ -86,7 +86,7 @@ void fill_topic_containers(
             name_and_type));
       }
       for (auto & sender : port_sample->m_senderList) {
-        auto name_and_type = rmw_iceoryx_cpp::get_name_n_type_from_iceoryx_service_description(
+        auto name_and_type = rmw_iceoryx_cpp::get_name_n_type_from_service_description(
           std::string(sender.m_caproServiceID.c_str()),
           std::string(sender.m_caproInstanceID.c_str()),
           std::string(sender.m_caproEventMethodID.c_str()));

--- a/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
+++ b/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
@@ -12,21 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rmw_iceoryx_cpp/iceoryx_name_conversion.hpp"
+
 #include <gtest/gtest.h>
 
-TEST(TestSuite, testCase1)
+TEST(NameConverisonTests, get_name_n_type_from_iceoryx_service_description)
 {
+  auto topic_and_type = rmw_iceoryx_cpp::get_name_n_type_from_iceoryx_service_description(
+    "SERVICE",
+    "INSTANCE",
+    "EVENT");
   EXPECT_TRUE(true);
 }
 
-TEST(TestSuite, testCase2)
+TEST(NameConverisonTests, get_service_description_elements)
 {
+  auto service_description = rmw_iceoryx_cpp::get_service_description_elements(
+    "TopicName",
+    "TypeName");
   EXPECT_TRUE(true);
-}
-
-TEST(TestSuite, testCase3)
-{
-  EXPECT_FALSE(false);
 }
 
 int main(int argc, char ** argv)

--- a/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
+++ b/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
@@ -16,9 +16,9 @@
 
 #include <gtest/gtest.h>
 
-TEST(NameConverisonTests, get_name_n_type_from_iceoryx_service_description)
+TEST(NameConverisonTests, get_name_n_type_from_service_description)
 {
-  auto topic_and_type = rmw_iceoryx_cpp::get_name_n_type_from_iceoryx_service_description(
+  auto topic_and_type = rmw_iceoryx_cpp::get_name_n_type_from_service_description(
     "SERVICE",
     "INSTANCE",
     "EVENT");
@@ -26,9 +26,9 @@ TEST(NameConverisonTests, get_name_n_type_from_iceoryx_service_description)
   EXPECT_EQ(std::get<1>(topic_and_type), "service_ara_msgs/msg/EVENT");
 }
 
-TEST(NameConverisonTests, get_service_description_elements_revers)
+TEST(NameConverisonTests, get_service_description_from_name_n_type_revers)
 {
-  auto service_description = rmw_iceoryx_cpp::get_service_description_elements(
+  auto service_description = rmw_iceoryx_cpp::get_service_description_from_name_n_type(
     "/INSTANCE/SERVICE/EVENT",
     "service_ara_msgs/msg/EVENT");
   EXPECT_EQ(std::get<0>(service_description), "SERVICE");
@@ -36,9 +36,9 @@ TEST(NameConverisonTests, get_service_description_elements_revers)
   EXPECT_EQ(std::get<2>(service_description), "EVENT");
 }
 
-TEST(NameConverisonTests, get_service_description_elements)
+TEST(NameConverisonTests, get_service_description_from_name_n_type)
 {
-  auto service_description = rmw_iceoryx_cpp::get_service_description_elements(
+  auto service_description = rmw_iceoryx_cpp::get_service_description_from_name_n_type(
     "TopicName",
     "TypeName");
   EXPECT_EQ(std::get<0>(service_description), "TypeName");
@@ -46,9 +46,9 @@ TEST(NameConverisonTests, get_service_description_elements)
   EXPECT_EQ(std::get<2>(service_description), "data");
 }
 
-TEST(NameConverisonTests, get_name_n_type_from_iceoryx_service_description_revers)
+TEST(NameConverisonTests, get_name_n_type_from_service_description_revers)
 {
-  auto topic_and_type = rmw_iceoryx_cpp::get_name_n_type_from_iceoryx_service_description(
+  auto topic_and_type = rmw_iceoryx_cpp::get_name_n_type_from_service_description(
     "TypeName",
     "TopicName",
     "data");

--- a/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
+++ b/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
@@ -22,7 +22,18 @@ TEST(NameConverisonTests, get_name_n_type_from_iceoryx_service_description)
     "SERVICE",
     "INSTANCE",
     "EVENT");
-  EXPECT_TRUE(true);
+  EXPECT_EQ(std::get<0>(topic_and_type), "/INSTANCE/SERVICE/EVENT");
+  EXPECT_EQ(std::get<1>(topic_and_type), "service_ara_msgs/msg/EVENT");
+}
+
+TEST(NameConverisonTests, get_service_description_elements_revers)
+{
+  auto service_description = rmw_iceoryx_cpp::get_service_description_elements(
+    "/INSTANCE/SERVICE/EVENT",
+    "service_ara_msgs/msg/EVENT");
+  EXPECT_EQ(std::get<0>(service_description), "SERVICE");
+  EXPECT_EQ(std::get<1>(service_description), "INSTANCE");
+  EXPECT_EQ(std::get<2>(service_description), "EVENT");
 }
 
 TEST(NameConverisonTests, get_service_description_elements)
@@ -30,7 +41,19 @@ TEST(NameConverisonTests, get_service_description_elements)
   auto service_description = rmw_iceoryx_cpp::get_service_description_elements(
     "TopicName",
     "TypeName");
-  EXPECT_TRUE(true);
+  EXPECT_EQ(std::get<0>(service_description), "TypeName");
+  EXPECT_EQ(std::get<1>(service_description), "TopicName");
+  EXPECT_EQ(std::get<2>(service_description), "data");
+}
+
+TEST(NameConverisonTests, get_name_n_type_from_iceoryx_service_description_revers)
+{
+  auto topic_and_type = rmw_iceoryx_cpp::get_name_n_type_from_iceoryx_service_description(
+    "TypeName",
+    "TopicName",
+    "data");
+  EXPECT_EQ(std::get<0>(topic_and_type), "TopicName");
+  EXPECT_EQ(std::get<1>(topic_and_type), "TypeName");
 }
 
 int main(int argc, char ** argv)

--- a/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
+++ b/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+TEST(TestSuite, testCase1)
+{
+    EXPECT_TRUE(true);
+}
+
+TEST(TestSuite, testCase2)
+{
+    EXPECT_TRUE(true);
+}
+
+TEST(TestSuite, testCase3)
+{
+    EXPECT_FALSE(false);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
+++ b/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
@@ -16,17 +16,17 @@
 
 TEST(TestSuite, testCase1)
 {
-    EXPECT_TRUE(true);
+  EXPECT_TRUE(true);
 }
 
 TEST(TestSuite, testCase2)
 {
-    EXPECT_TRUE(true);
+  EXPECT_TRUE(true);
 }
 
 TEST(TestSuite, testCase3)
 {
-    EXPECT_FALSE(false);
+  EXPECT_FALSE(false);
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
To be able to use `iceoryx`s native applications with `ros 2` based applications the package name defined from service and event name must be valid for `ros 2` as package name. Forcing lowercase in the package name only partially fixes this issue. As far as I know there are changes planned regarding types in `iceoryx`, so I would propose this fix, till we can focus on the new type handling.