### PR TITLE
support for rosbags

### DIFF
--- a/.github/workflows/iceoryx.yml
+++ b/.github/workflows/iceoryx.yml
@@ -2,6 +2,8 @@ name: Build iceoryx
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     # schedule daily at 03:00

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Integration build rmw_iceoryx
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/rmw_iceoryx_cpp/CMakeLists.txt
+++ b/rmw_iceoryx_cpp/CMakeLists.txt
@@ -31,6 +31,7 @@ if(NOT iceoryx_posh_FOUND)
   message(WARNING "iceoryx not found - skipping '${PROJECT_NAME}'")
   return()
 endif()
+find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
@@ -64,6 +65,7 @@ target_link_libraries(rmw_iceoryx_name_conversion
   iceoryx_posh::iceoryx_posh
 )
 ament_target_dependencies(rmw_iceoryx_name_conversion
+  rcpputils
   rcutils
   rmw
   rosidl_generator_c

--- a/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_deserialize.hpp
+++ b/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_deserialize.hpp
@@ -25,11 +25,11 @@ struct MessageMembers;
 namespace rmw_iceoryx_cpp
 {
 
+// TODO(karsten1987): This should be `uint8`, really
 const char * deserialize(
   const char * serialized_msg,
   const rosidl_typesupport_introspection_c__MessageMembers * members,
   void * ros_message);
-
 
 const char * deserialize(
   const char * serialized_msg,

--- a/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_name_conversion.hpp
+++ b/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_name_conversion.hpp
@@ -26,12 +26,31 @@ class rosidl_message_type_support_t;
 namespace rmw_iceoryx_cpp
 {
 
+/// Get the pair of ROS topic and type from a given iceoryx service triplet.
+/**
+ * Given a triplet of `service`, `instance`, `event`, convert these to a ROS2 conform
+ * tuple of `topic` and `type`.
+ * For a regular ROS2 pair, the event name should be set to "data".
+ * \param service the iceoryx service description
+ * \param instance the iceoryx instance description
+ * \param event the iceoryx event description
+ * \return tuple of topic and type
+ */
 std::tuple<std::string, std::string>
 get_name_n_type_from_service_description(
   const std::string & service,
   const std::string & instance,
   const std::string & event);
 
+/// Get the iceoryx service triplet description from a given pair of ROS topic and type.
+/**
+ * Given a pair in the form of topic name and type, generate a iceoryx service description triplet.
+ * By convention, the iceoryx event field is set to "data".
+ * \param service the iceoryx service description
+ * \param instance the iceoryx instance description
+ * \param event the iceoryx event description
+ * \return triple of iceoryx `service`, `instance`, `event`.
+ */
 std::tuple<std::string, std::string, std::string>
 get_service_description_from_name_n_type(
   const std::string & topic_name,

--- a/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_topic_names_and_types.hpp
+++ b/rmw_iceoryx_cpp/include/rmw_iceoryx_cpp/iceoryx_topic_names_and_types.hpp
@@ -43,8 +43,7 @@ std::map<std::string, std::string> get_subscription_names_and_types_of_node(
 
 rmw_ret_t fill_rmw_names_and_types(
   rmw_names_and_types_t * rmw_topic_names_and_types,
-  const std::map<std::string,
-  std::string> & iceoryx_topic_names_and_types,
+  const std::map<std::string, std::string> & iceoryx_topic_names_and_types,
   rcutils_allocator_t * allocator);
 
 }  // namespace rmw_iceoryx_cpp

--- a/rmw_iceoryx_cpp/package.xml
+++ b/rmw_iceoryx_cpp/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>iceoryx_posh</depend>
+  <depend>rcpputils</depend>
   <depend>rcutils</depend>
   <depend>rmw</depend>
   <depend>rmw_implementation</depend>

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -79,7 +79,7 @@ get_name_n_type_from_service_description(
 
     return std::make_tuple(
       "/" + delimiter_msg + instance + "/" + service + "/" + event,
-      "iceoryx_introspection/msg/" + event);
+      "iceoryx_introspection_msgs/msg/" + event);
   } else {
     // ARA Naming
     std::string service_lowercase = service;

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -79,7 +79,7 @@ get_name_n_type_from_service_description(
 
     return std::make_tuple(
       "/" + delimiter_msg + instance + "/" + service + "/" + event,
-       "iceoryx_introspection/msg/" + event);     
+      "iceoryx_introspection/msg/" + event);
   } else {
     // ARA Naming
     std::string service_lowercase = service;

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -73,16 +73,24 @@ get_name_n_type_from_service_description(
   if (event == ROS2_EVENT_NAME) {
     // ROS 2.0 Naming
     return std::make_tuple(instance, service);
-  }
-  // ARA Naming
-  std::string service_lowercase = service;
-  std::transform(
-    service_lowercase.begin(), service_lowercase.end(),
-    service_lowercase.begin(), ::tolower);
+  } else if (service.find("Introspection") != std::string::npos) {
+    // iceoryx built-in topic handling
+    std::string delimiter_msg = "_iceoryx/";
 
-  return std::make_tuple(
-    "/" + instance + "/" + service + "/" + event,
-    service_lowercase + ARA_DELIMITER + event);
+    return std::make_tuple(
+      "/" + delimiter_msg + instance + "/" + service + "/" + event,
+       "iceoryx_introspection/msg/" + event);     
+  } else {
+    // ARA Naming
+    std::string service_lowercase = service;
+    std::transform(
+      service_lowercase.begin(), service_lowercase.end(),
+      service_lowercase.begin(), ::tolower);
+
+    return std::make_tuple(
+      "/" + instance + "/" + service + "/" + event,
+      service_lowercase + ARA_DELIMITER + event);
+  }
 }
 
 std::tuple<std::string, std::string, std::string> get_service_description_from_name_n_type(

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -80,7 +80,7 @@ get_name_n_type_from_service_description(
     std::string delimiter_msg = "_iceoryx";
 
     return std::make_tuple(
-      delimiter_msg + "/" + instance + "/" + service + "/" + event,
+      "/" + delimiter_msg + "/" + instance + "/" + service + "/" + event,
       std::string(ICEORYX_INTROSPECTION_MSG_PACKAGE) + "/msg/" + event);
   }
 
@@ -109,7 +109,7 @@ get_service_description_from_name_n_type(
   // Filter out inbuilt introspection topics
   auto position_introspection_msgs = type_name.find(ICEORYX_INTROSPECTION_MSG_PACKAGE);
   if (position_introspection_msgs != std::string::npos) {
-    auto tokens = rcpputils::split(topic_name, '/');
+    auto tokens = rcpputils::split(topic_name, '/', true);  // skip_empty for leading `/`
     if (tokens.size() != 4) {  // ['_iceoryx', <instance>, <service>, <event>]
       throw std::runtime_error(std::string("inbuilt topic name is malformed: ") + topic_name);
     }

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_name_conversion.cpp
@@ -17,6 +17,8 @@
 #include <string>
 #include <tuple>
 
+#include "rcpputils/split.hpp"
+
 #include "rosidl_generator_c/primitives_sequence.h"
 #include "rosidl_generator_c/primitives_sequence_functions.h"
 
@@ -38,6 +40,7 @@
 static constexpr char ARA_DELIMITER[] = "_ara_msgs/msg/";
 static constexpr char ROS2_EVENT_NAME[] = "data";
 static constexpr char ICEORYX_INTROSPECTION_SERVICE[] = "Introspection";
+static constexpr char ICEORYX_INTROSPECTION_MSG_PACKAGE[] = "iceoryx_introspection_msgs";
 
 inline std::string to_message_type(const std::string & in)
 {
@@ -70,19 +73,21 @@ get_name_n_type_from_service_description(
   const std::string & instance,
   const std::string & event)
 {
-  if (event == ROS2_EVENT_NAME) {
-    // ROS 2.0 Naming
-    return std::make_tuple(instance, service);
-  }
-
+  // Filter out inbuilt introspection topics
   if (service.find(ICEORYX_INTROSPECTION_SERVICE) != std::string::npos) {
     // iceoryx built-in topic handling
     // mark as hidden with leading `_`
-    std::string delimiter_msg = "_iceoryx/";
+    std::string delimiter_msg = "_iceoryx";
 
     return std::make_tuple(
-      "/" + delimiter_msg + instance + "/" + service + "/" + event,
-      "iceoryx_introspection_msgs/msg/" + event);
+      delimiter_msg + "/" + instance + "/" + service + "/" + event,
+      std::string(ICEORYX_INTROSPECTION_MSG_PACKAGE) + "/msg/" + event);
+  }
+
+  // ROS 2.0 Naming
+  if (event == ROS2_EVENT_NAME) {
+    // we simply throw away `event` as it was artificially introduced anyway.
+    return std::make_tuple(instance, service);
   }
 
   // ARA Naming
@@ -101,11 +106,20 @@ get_service_description_from_name_n_type(
   const std::string & topic_name,
   const std::string & type_name)
 {
+  // Filter out inbuilt introspection topics
+  auto position_introspection_msgs = type_name.find(ICEORYX_INTROSPECTION_MSG_PACKAGE);
+  if (position_introspection_msgs != std::string::npos) {
+    auto tokens = rcpputils::split(topic_name, '/');
+    if (tokens.size() != 4) {  // ['_iceoryx', <instance>, <service>, <event>]
+      throw std::runtime_error(std::string("inbuilt topic name is malformed: ") + topic_name);
+    }
+    return std::make_tuple(tokens[2], tokens[1], tokens[3]);
+  }
+
   auto position_ara_delimiter = type_name.find(ARA_DELIMITER);
 
+  // ROS 2.0 Naming
   if (position_ara_delimiter == std::string::npos) {
-    // ROS 2.0 Naming
-    // TODO(karsten1987): Filter out iceoryx Introspection topics
     return std::make_tuple(type_name, topic_name, ROS2_EVENT_NAME);
   }
 

--- a/rmw_iceoryx_cpp/src/rmw_serialize.cpp
+++ b/rmw_iceoryx_cpp/src/rmw_serialize.cpp
@@ -12,9 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <vector>
+
 #include "rcutils/error_handling.h"
 
 #include "rmw/rmw.h"
+
+#include "rmw_iceoryx_cpp/iceoryx_serialize.hpp"
+#include "rmw_iceoryx_cpp/iceoryx_type_info_introspection.hpp"
+
+#include "rosidl_typesupport_introspection_c/identifier.h"
+
+#include "rosidl_typesupport_introspection_cpp/identifier.hpp"
+
+namespace details
+{
+rmw_ret_t
+copy_payload(
+  rmw_serialized_message_t * serialized_message,
+  const void * payload,
+  size_t payload_size)
+{
+  auto ret = rmw_serialized_message_resize(serialized_message, payload_size);
+  if (RMW_RET_OK == ret) {
+    memcpy(serialized_message->buffer, payload, payload_size);
+    serialized_message->buffer_length = payload_size;
+  }
+  return ret;
+}
+}  // namespace details
 
 extern "C"
 {
@@ -28,8 +54,36 @@ rmw_serialize(
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(type_supports, RMW_RET_ERROR);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(serialized_message, RMW_RET_ERROR);
 
-  assert(false);
-  return RMW_RET_OK;
+  // it's a fixed size message, so we memcpy
+  if (rmw_iceoryx_cpp::iceoryx_is_fixed_size(type_supports)) {
+    return details::copy_payload(
+      serialized_message, ros_message, rmw_iceoryx_cpp::iceoryx_get_message_size(type_supports));
+  }
+
+  // message is neither loaned nor fixed size, so we have to serialize
+  std::vector<char> payload_vector{};
+
+  // serialize with cpp typesupport
+  auto ts_cpp = get_message_typesupport_handle(
+    type_supports,
+    rosidl_typesupport_introspection_cpp::typesupport_identifier);
+  if (ts_cpp != nullptr) {
+    auto members =
+      static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(ts_cpp->data);
+    rmw_iceoryx_cpp::serialize(ros_message, members, payload_vector);
+  }
+
+  // serialize with c typesupport
+  auto ts_c = get_message_typesupport_handle(
+    type_supports,
+    rosidl_typesupport_introspection_c__identifier);
+  if (ts_c != nullptr) {
+    auto members =
+      static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(ts_c->data);
+    rmw_iceoryx_cpp::serialize(ros_message, members, payload_vector);
+  }
+
+  return details::copy_payload(serialized_message, payload_vector.data(), payload_vector.size());
 }
 
 rmw_ret_t
@@ -56,7 +110,8 @@ rmw_get_serialized_message_size(
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(message_bounds, RMW_RET_ERROR);
   RCUTILS_CHECK_ARGUMENT_FOR_NULL(size, RMW_RET_ERROR);
 
-  assert(false);
+  *size = rmw_iceoryx_cpp::iceoryx_get_message_size(type_supports);
+
   return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_iceoryx_cpp/src/rmw_serialize.cpp
+++ b/rmw_iceoryx_cpp/src/rmw_serialize.cpp
@@ -61,7 +61,7 @@ rmw_serialize(
       serialized_message, ros_message, rmw_iceoryx_cpp::iceoryx_get_message_size(type_supports));
   }
 
-  // message is neither loaned nor fixed size, so we have to serialize
+  // it's no fixed size message, so we have to serialize
   std::vector<char> payload_vector{};
 
   // serialize with cpp typesupport

--- a/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
+++ b/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
@@ -93,10 +93,10 @@ TEST(NameConverisonTests, flip_flop)
 TEST(NameConverisonTests, flip_flop_reverse)
 {
   std::vector<std::tuple<std::string, std::string, std::string>> topic_names_and_types =
-  {{"instance1", "service1", "event1"},
-    {"instance2", "service2", "event2"},
-    {"RouDI_1", "Introspection", "event1"},
-    {"topic1", "type1", "data"}};
+  {{"service1", "instance1", "event1"},
+    {"service2", "instance2", "event2"},
+    {"Introspection", "RouDI_1", "event1"},
+    {"type1", "topic1", "data"}};
 
   for (auto & tuple : topic_names_and_types) {
     auto ros_tuple = rmw_iceoryx_cpp::get_name_n_type_from_service_description(

--- a/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
+++ b/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
@@ -66,7 +66,7 @@ TEST(NameConverisonTests, get_hidden_introspection_topic)
     "Introspection",
     "RouDI_ID",
     "foo");
-  EXPECT_EQ(std::get<0>(topic_and_type), "_iceoryx/RouDI_ID/Introspection/foo");
+  EXPECT_EQ(std::get<0>(topic_and_type), "/_iceoryx/RouDI_ID/Introspection/foo");
   EXPECT_EQ(std::get<1>(topic_and_type), "iceoryx_introspection_msgs/msg/foo");
 }
 
@@ -76,8 +76,8 @@ TEST(NameConverisonTests, flip_flop)
   {{"topic1", "type1"},
     {"topic2", "type2"},
     {"topic3", "type3"},
-    {"_iceoryx/RouDI_1/Introspection/event1", "iceoryx_introspection_msgs/msg/event1"},
-    {"_iceoryx/RouDI_1/Introspection/event2", "iceoryx_introspection_msgs/msg/event2"}};
+    {"/_iceoryx/RouDI_1/Introspection/event1", "iceoryx_introspection_msgs/msg/event1"},
+    {"/_iceoryx/RouDI_1/Introspection/event2", "iceoryx_introspection_msgs/msg/event2"}};
 
   for (auto & tuple : topic_names_and_types) {
     auto service_tuple =

--- a/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
+++ b/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
@@ -56,6 +56,16 @@ TEST(NameConverisonTests, get_name_n_type_from_service_description_revers)
   EXPECT_EQ(std::get<1>(topic_and_type), "TypeName");
 }
 
+TEST(NameConverisonTests, get_hidden_topic)
+{
+  auto topic_and_type = rmw_iceoryx_cpp::get_name_n_type_from_service_description(
+    "Introspection",
+    "RouDI_ID",
+    "foo");
+  EXPECT_EQ(std::get<0>(topic_and_type), "/_iceoryx/RouDI_ID/Introspection/foo");
+  EXPECT_EQ(std::get<1>(topic_and_type), "iceoryx_introspection_msgs/msg/foo");
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
+++ b/rmw_iceoryx_cpp/test/iceoryx_name_conversion_test.cpp
@@ -22,8 +22,8 @@ TEST(NameConverisonTests, get_name_n_type_from_service_description)
     "SERVICE",
     "INSTANCE",
     "EVENT");
-  EXPECT_EQ(std::get<0>(topic_and_type), "/INSTANCE/SERVICE/EVENT");
-  EXPECT_EQ(std::get<1>(topic_and_type), "service_ara_msgs/msg/EVENT");
+  EXPECT_EQ("/INSTANCE/SERVICE/EVENT", std::get<0>(topic_and_type));
+  EXPECT_EQ("service_ara_msgs/msg/EVENT", std::get<1>(topic_and_type));
 }
 
 TEST(NameConverisonTests, get_service_description_from_name_n_type_revers)
@@ -31,9 +31,9 @@ TEST(NameConverisonTests, get_service_description_from_name_n_type_revers)
   auto service_description = rmw_iceoryx_cpp::get_service_description_from_name_n_type(
     "/INSTANCE/SERVICE/EVENT",
     "service_ara_msgs/msg/EVENT");
-  EXPECT_EQ(std::get<0>(service_description), "SERVICE");
-  EXPECT_EQ(std::get<1>(service_description), "INSTANCE");
-  EXPECT_EQ(std::get<2>(service_description), "EVENT");
+  EXPECT_EQ("SERVICE", std::get<0>(service_description));
+  EXPECT_EQ("INSTANCE", std::get<1>(service_description));
+  EXPECT_EQ("EVENT", std::get<2>(service_description));
 }
 
 TEST(NameConverisonTests, get_service_description_from_name_n_type)
@@ -41,9 +41,9 @@ TEST(NameConverisonTests, get_service_description_from_name_n_type)
   auto service_description = rmw_iceoryx_cpp::get_service_description_from_name_n_type(
     "TopicName",
     "TypeName");
-  EXPECT_EQ(std::get<0>(service_description), "TypeName");
-  EXPECT_EQ(std::get<1>(service_description), "TopicName");
-  EXPECT_EQ(std::get<2>(service_description), "data");
+  EXPECT_EQ("TypeName", std::get<0>(service_description));
+  EXPECT_EQ("TopicName", std::get<1>(service_description));
+  EXPECT_EQ("data", std::get<2>(service_description));
 }
 
 TEST(NameConverisonTests, get_name_n_type_from_service_description_revers)
@@ -52,8 +52,8 @@ TEST(NameConverisonTests, get_name_n_type_from_service_description_revers)
     "TypeName",
     "TopicName",
     "data");
-  EXPECT_EQ(std::get<0>(topic_and_type), "TopicName");
-  EXPECT_EQ(std::get<1>(topic_and_type), "TypeName");
+  EXPECT_EQ("TopicName", std::get<0>(topic_and_type));
+  EXPECT_EQ("TypeName", std::get<1>(topic_and_type));
 }
 
 TEST(NameConverisonTests, get_hidden_topic)


### PR DESCRIPTION
fixes #13 

this is work in progress. 

* hide internal topics to avoid recording with `ros2 bag record -a`. This change requires https://github.com/ros2/rosbag2/pull/332
* support for `rmw_serialize` as well as `rmw_publish_serialized_message`
* support for `rmw_deserialize` as well as `rmw_take_serialized_message`