### PR TITLE
publisher handle returns shared pointer

### DIFF
--- a/iceoryx_ros2_bridge/src/generic_publisher.cpp
+++ b/iceoryx_ros2_bridge/src/generic_publisher.cpp
@@ -39,7 +39,7 @@ void GenericPublisher::publish(std::shared_ptr<rmw_serialized_message_t> message
 void GenericPublisher::publish(const rmw_serialized_message_t * message)
 {
   auto return_code = rcl_publish_serialized_message(
-    get_publisher_handle(), message, NULL);
+    get_publisher_handle().get(), message, NULL);
 
   if (return_code != RCL_RET_OK) {
     rclcpp::exceptions::throw_from_rcl_error(return_code, "failed to publish serialized message");


### PR DESCRIPTION
https://github.com/ros2/rclcpp/pull/1119 introduced an API break. 

Signed-off-by: Knese Karsten <karsten.knese@us.bosch.com>