### PR TITLE
disable cron job for rmw_iceoryx

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: '0 3 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
given that the current rmw_iceoryx_cpp is not working with the latest iceoryx version, I am going to disable the GH actions for this.

@budrus I'll leave it up to you to re-enable them once iceoryx v1.0 is out of the door and work on the rmw is going to be resumed.