### PR TITLE
Add gid support

### DIFF
--- a/rmw_iceoryx_cpp/src/iceoryx_generate_gid.hpp
+++ b/rmw_iceoryx_cpp/src/iceoryx_generate_gid.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +18,8 @@
 
 #include "rmw/types.h"
 
-rmw_gid_t generate_gid();
+#include "iceoryx_posh/popo/untyped_publisher.hpp"
+
+rmw_gid_t generate_subscriber_gid(iox::popo::UntypedPublisher * const publisher);
 
 #endif  // ICEORYX_GENERATE_GID_HPP_

--- a/rmw_iceoryx_cpp/src/iceoryx_generate_gid.hpp
+++ b/rmw_iceoryx_cpp/src/iceoryx_generate_gid.hpp
@@ -20,6 +20,6 @@
 
 #include "iceoryx_posh/popo/untyped_publisher.hpp"
 
-rmw_gid_t generate_subscriber_gid(iox::popo::UntypedPublisher * const publisher);
+rmw_gid_t generate_publisher_gid(iox::popo::UntypedPublisher * const publisher);
 
 #endif  // ICEORYX_GENERATE_GID_HPP_

--- a/rmw_iceoryx_cpp/src/internal/iceoryx_generate_gid.cpp
+++ b/rmw_iceoryx_cpp/src/internal/iceoryx_generate_gid.cpp
@@ -19,11 +19,11 @@
 
 #include "iceoryx_posh/popo/untyped_publisher.hpp"
 
-rmw_gid_t generate_subscriber_gid(iox::popo::UntypedPublisher * const publisher)
+rmw_gid_t generate_publisher_gid(iox::popo::UntypedPublisher * const publisher)
 {
   rmw_gid_t gid;
   gid.implementation_identifier = rmw_get_implementation_identifier();
-  memset(&gid.data[0], 0, RMW_GID_STORAGE_SIZE);
+  memset(gid.data, 0, RMW_GID_STORAGE_SIZE);
 
   iox::UniquePortId typed_uid = publisher->getUid();
   iox::UniquePortId::value_type uid = static_cast<iox::UniquePortId::value_type>(typed_uid);
@@ -33,7 +33,7 @@ rmw_gid_t generate_subscriber_gid(iox::popo::UntypedPublisher * const publisher)
     RMW_SET_ERROR_MSG("Could not generated gid");
     return gid;
   }
-  memcpy(&gid.data[0], &uid, size);
+  memcpy(gid.data, &uid, size);
 
   return gid;
 }

--- a/rmw_iceoryx_cpp/src/rmw_compare_guids_equal.cpp
+++ b/rmw_iceoryx_cpp/src/rmw_compare_guids_equal.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "rcutils/error_handling.h"
+#include <cstring>
 
+#include "rcutils/error_handling.h"
 #include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
 
-#include <cstring>
 
 extern "C"
 {
@@ -42,8 +42,7 @@ rmw_compare_gids_equal(
     rmw_get_implementation_identifier(),
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
-  if (std::memcmp(gid1->data, gid2->data, sizeof(gid1->data)) == 0)
-  {
+  if (std::memcmp(gid1->data, gid2->data, sizeof(gid1->data)) == 0) {
     *result = true;
   }
   return RMW_RET_OK;

--- a/rmw_iceoryx_cpp/src/rmw_compare_guids_equal.cpp
+++ b/rmw_iceoryx_cpp/src/rmw_compare_guids_equal.cpp
@@ -17,6 +17,8 @@
 #include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
 
+#include <cstring>
+
 extern "C"
 {
 rmw_ret_t
@@ -27,10 +29,23 @@ rmw_compare_gids_equal(
 {
   *result = false;
 
-  RCUTILS_CHECK_ARGUMENT_FOR_NULL(gid1, RMW_RET_ERROR);
-  RCUTILS_CHECK_ARGUMENT_FOR_NULL(gid2, RMW_RET_ERROR);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(gid1, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    gid1,
+    gid1->implementation_identifier,
+    rmw_get_implementation_identifier(),
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(gid2, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    gid2,
+    gid2->implementation_identifier,
+    rmw_get_implementation_identifier(),
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
-  RMW_SET_ERROR_MSG("rmw_iceoryx_cpp does not support gids.");
-  return RMW_RET_UNSUPPORTED;
+  if (std::memcmp(gid1->data, gid2->data, sizeof(gid1->data)) == 0)
+  {
+    *result = true;
+  }
+  return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_iceoryx_cpp/src/rmw_compare_guids_equal.cpp
+++ b/rmw_iceoryx_cpp/src/rmw_compare_guids_equal.cpp
@@ -42,7 +42,7 @@ rmw_compare_gids_equal(
     rmw_get_implementation_identifier(),
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
-  if (std::memcmp(gid1->data, gid2->data, sizeof(gid1->data)) == 0) {
+  if (std::memcmp(gid1->data, gid2->data, RMW_GID_STORAGE_SIZE) == 0) {
     *result = true;
   }
   return RMW_RET_OK;

--- a/rmw_iceoryx_cpp/src/rmw_get_gid_for_publisher.cpp
+++ b/rmw_iceoryx_cpp/src/rmw_get_gid_for_publisher.cpp
@@ -25,18 +25,19 @@ extern "C"
 rmw_ret_t
 rmw_get_gid_for_publisher(const rmw_publisher_t * publisher, rmw_gid_t * gid)
 {
-  RCUTILS_CHECK_ARGUMENT_FOR_NULL(publisher, RMW_RET_ERROR);
-  RCUTILS_CHECK_ARGUMENT_FOR_NULL(gid, RMW_RET_ERROR);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(publisher, RMW_RET_INVALID_ARGUMENT);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(gid, RMW_RET_INVALID_ARGUMENT);
 
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     rmw_get_gid_for_publisher
     : publisher, publisher->implementation_identifier,
-    rmw_get_implementation_identifier(), return RMW_RET_ERROR);
+    rmw_get_implementation_identifier(),
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   IceoryxPublisher * iceoryx_publisher = static_cast<IceoryxPublisher *>(publisher->data);
   if (!iceoryx_publisher) {
     RMW_SET_ERROR_MSG("publisher info handle is null");
-    return RMW_RET_ERROR;
+    return RMW_RET_INVALID_ARGUMENT;
   }
   *gid = iceoryx_publisher->gid_;
   return RMW_RET_OK;

--- a/rmw_iceoryx_cpp/src/types/iceoryx_publisher.hpp
+++ b/rmw_iceoryx_cpp/src/types/iceoryx_publisher.hpp
@@ -32,7 +32,7 @@ struct IceoryxPublisher
     iox::popo::UntypedPublisher * const iceoryx_sender)
   : type_supports_(*type_supports),
     iceoryx_sender_(iceoryx_sender),
-    gid_(generate_subscriber_gid(iceoryx_sender_)),
+    gid_(generate_publisher_gid(iceoryx_sender_)),
     is_fixed_size_(rmw_iceoryx_cpp::iceoryx_is_fixed_size(type_supports)),
     message_size_(rmw_iceoryx_cpp::iceoryx_get_message_size(type_supports))
   {}

--- a/rmw_iceoryx_cpp/src/types/iceoryx_publisher.hpp
+++ b/rmw_iceoryx_cpp/src/types/iceoryx_publisher.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2022 by Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@ struct IceoryxPublisher
     iox::popo::UntypedPublisher * const iceoryx_sender)
   : type_supports_(*type_supports),
     iceoryx_sender_(iceoryx_sender),
-    gid_(generate_gid()),
+    gid_(generate_subscriber_gid(iceoryx_sender_)),
     is_fixed_size_(rmw_iceoryx_cpp::iceoryx_is_fixed_size(type_supports)),
     message_size_(rmw_iceoryx_cpp::iceoryx_get_message_size(type_supports))
   {}


### PR DESCRIPTION
* Use `iox::UniquePortId` from iceoryx
* Implement `rmw_compare_gids_equal()`

Closes #47

Signed-off-by: Simon Hoinkis simon.hoinkis@apex.ai